### PR TITLE
Refactors

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@ export const parameters = {
         'Intro',
         'Internationalization',
         'Example',
-        ['AweInput', 'Select', 'FiltersForm', 'EditableTable'],
+        ['AweInput', 'Select', 'ApiSelect', 'FiltersForm', 'EditableTable'],
       ],
     },
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@ export const parameters = {
         'Intro',
         'Internationalization',
         'Example',
-        ['AweInput', 'FiltersForm', 'EditableTable'],
+        ['AweInput', 'Select', 'FiltersForm', 'EditableTable'],
       ],
     },
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,7 @@ export const parameters = {
         'Intro',
         'Internationalization',
         'Example',
-        ['AweInput', 'Select', 'ApiSelect', 'FiltersForm', 'EditableTable'],
+        ['Input', 'Select', 'ApiSelect', 'FiltersForm', 'EditableTable'],
       ],
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@galiojs/awesome-antd",
-  "version": "0.1.11-beta.5",
+  "version": "0.1.11-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api-select/__test__/index.test.tsx
+++ b/src/api-select/__test__/index.test.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import AweApiSelect from './..';
+import ApiSelect from './..';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -25,11 +25,11 @@ const options = [
   { text: 'React(2)', label: 'React', value: '2' },
 ];
 
-describe('Testing <AweApiSelect />', () => {
+describe('Testing <ApiSelect />', () => {
   test('fetches options from an API and displays them', async () => {
     mockedAxios.get.mockImplementationOnce(() => Promise.resolve({ data: options }));
 
-    render(<AweApiSelect dataService={dataService} />);
+    render(<ApiSelect dataService={dataService} />);
 
     await userEvent.click(screen.getByRole('combobox'));
 
@@ -40,10 +40,10 @@ describe('Testing <AweApiSelect />', () => {
     expect(items).toHaveLength(2);
   });
 
-  test('turns on `requestOnDidMount`', async () => {
+  test('did mount mode', async () => {
     mockedAxios.get.mockImplementationOnce(() => Promise.resolve({ data: options }));
 
-    render(<AweApiSelect defaultOpen requestOnDidMount dataService={dataService} />);
+    render(<ApiSelect defaultOpen requestOnDidMount dataService={dataService} />);
 
     await screen.findByText('Hello');
     await screen.findByText('React');
@@ -56,7 +56,7 @@ describe('Testing <AweApiSelect />', () => {
     mockedAxios.get.mockImplementationOnce(() => Promise.resolve({ data: options }));
 
     render(
-      <AweApiSelect
+      <ApiSelect
         showSearch
         defaultOpen
         requestOnDidMount
@@ -76,7 +76,7 @@ describe('Testing <AweApiSelect />', () => {
     expect(screen.queryByText('React-2')).toBeNull();
   });
 
-  test('handle `onSearch`', async () => {
+  test('search mode', async () => {
     mockedAxios.get.mockImplementation((__, { params: { keyword } }) => {
       return Promise.resolve({
         data: options.filter(({ label }) =>
@@ -85,7 +85,7 @@ describe('Testing <AweApiSelect />', () => {
       });
     });
 
-    render(<AweApiSelect showSearch trigger="onSearch" dataService={searchDataService} />);
+    render(<ApiSelect trigger="onSearch" dataService={searchDataService} />);
 
     await userEvent.click(screen.getByRole('combobox'));
     await userEvent.type(screen.getByRole('textbox'), 'hello');
@@ -94,8 +94,9 @@ describe('Testing <AweApiSelect />', () => {
     expect(screen.queryByText('React')).toBeNull();
 
     await userEvent.clear(screen.getByRole('textbox'));
-
     await screen.findByText('Hello');
+
+    await userEvent.type(screen.getByRole('textbox'), 'react');
     await screen.findByText('React');
   });
 
@@ -109,14 +110,14 @@ describe('Testing <AweApiSelect />', () => {
     });
 
     const { rerender } = render(
-      <AweApiSelect serviceQueries={['hello']} dataService={searchDataService} />
+      <ApiSelect serviceQueries={['hello']} dataService={searchDataService} />
     );
 
     await userEvent.click(screen.getByRole('combobox'));
     await screen.findByText('Hello');
     expect(screen.queryByText('React')).toBeNull();
 
-    rerender(<AweApiSelect serviceQueries={['react']} dataService={searchDataService} />);
+    rerender(<ApiSelect serviceQueries={['react']} dataService={searchDataService} />);
     await screen.findByText('React');
     expect(screen.queryByText('Hello')).toBeNull();
   });

--- a/src/api-select/index.tsx
+++ b/src/api-select/index.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 import { SelectValue } from 'antd/lib/select';
 
 import { DataService } from './../renderProps/data-service';
-import AweSelect, { AweSelectProps } from './../select';
+import Select, { SelectProps } from './../select';
 
 type FieldNames = {
   dataLabel?: string | ((option: any) => string);
@@ -14,7 +14,7 @@ type FieldNames = {
 
 type EnhancedOnChange = (value: SelectValue, option: any, optionElem: React.ReactElement) => void;
 
-export interface AweApiSelectProps extends AweSelectProps {
+export interface AweApiSelectProps extends SelectProps {
   /**
    * @deprecated As of release v0.1.3, replaced by {@link #trigger}.
    *   The same as `trigger="onDidMount"`.
@@ -137,7 +137,7 @@ export class AweApiSelect extends React.PureComponent<AweApiSelectProps> {
         dataService={dataService}
       >
         {({ data = [] }) => (
-          <AweSelect
+          <Select
             optionFilterProp="data-label"
             filterOption={defaultFilterOption}
             {...rest}
@@ -155,17 +155,12 @@ export class AweApiSelect extends React.PureComponent<AweApiSelectProps> {
               const disabled = (disabledOptionValues as string[]).includes(value);
 
               return (
-                <AweSelect.Option
-                  key={value}
-                  value={value}
-                  disabled={disabled}
-                  data-label={dataLabel}
-                >
+                <Select.Option key={value} value={value} disabled={disabled} data-label={dataLabel}>
                   {label}
-                </AweSelect.Option>
+                </Select.Option>
               );
             })}
-          </AweSelect>
+          </Select>
         )}
       </DataService>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,10 @@ export { default as ApiSelect } from './api-select';
 
 export { default as AweCascader } from './cascader';
 export { default as AweApiCascader } from './api-cascader';
+
 export { default as AweInput } from './input';
+export { default as Input } from './input';
+
 export { default as AweTag } from './tag';
 export { default as AweButton } from './button';
 export { default as AweTable, createEditableTable } from './table';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,8 @@ export { default as AweSelect } from './select';
 export { default as Select } from './select';
 
 export { default as AweApiSelect } from './api-select';
+export { default as ApiSelect } from './api-select';
+
 export { default as AweCascader } from './cascader';
 export { default as AweApiCascader } from './api-cascader';
 export { default as AweInput } from './input';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,10 @@
 export * from 'antd/lib';
 
 export { default as AweTreeSelect } from './tree-select';
+
 export { default as AweSelect } from './select';
+export { default as Select } from './select';
+
 export { default as AweApiSelect } from './api-select';
 export { default as AweCascader } from './cascader';
 export { default as AweApiCascader } from './api-cascader';

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -1,3 +1,3 @@
-import AweInput from './input';
+import Input from './input';
 
-export default AweInput;
+export default Input;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import Input, { InputProps } from 'antd/lib/input';
+import AntInput, { InputProps as AntInputProps } from 'antd/lib/input';
 
 import LengthCount from './length-count';
 import TextArea from './textarea';
 
-export interface AweInputProps extends InputProps {
+export interface InputProps extends AntInputProps {
   showLengthCount: boolean;
 }
 
-export class AweInput extends React.PureComponent<AweInputProps> {
+export class Input extends React.PureComponent<InputProps> {
   static TextArea = TextArea;
 
   static defaultProps = {
@@ -21,7 +21,7 @@ export class AweInput extends React.PureComponent<AweInputProps> {
     return (
       <LengthCount {...this.props}>
         {({ lengthCount, onChange }) => (
-          <Input
+          <AntInput
             {...restProps}
             suffix={showLengthCount ? lengthCount : suffix}
             onChange={onChange}
@@ -32,4 +32,4 @@ export class AweInput extends React.PureComponent<AweInputProps> {
   }
 }
 
-export default AweInput;
+export default Input;

--- a/src/renderProps/data-service.tsx
+++ b/src/renderProps/data-service.tsx
@@ -4,32 +4,34 @@ import shallowequal from 'shallowequal';
 
 export type DataUpdatedCallback = (data: any) => void;
 
-export interface DataServiceProps {
+export interface DataServiceProps<D> {
   requestOnDidMount?: boolean;
   queries?: any[];
   dataService: (...queries: any[]) => any;
   onDataUpdated?: DataUpdatedCallback;
   children: (
-    provided: { data: any; requesting?: boolean },
+    provided: { data?: D; requesting?: boolean },
     transmittedProps?: any
   ) => React.ReactChild;
 }
 
-export interface DataServiceState {
+export interface DataServiceState<D> {
   requesting: boolean;
-  data: any;
+  data?: D;
 }
 
 const OWN_PROPS = ['requestOnDidMount', 'dataService', 'children'];
 
-export class DataService extends React.PureComponent<DataServiceProps, DataServiceState> {
-  static defaultProps: Partial<DataServiceProps> = {
+export class DataService<D = any> extends React.PureComponent<
+  DataServiceProps<D>,
+  DataServiceState<D>
+> {
+  static defaultProps = {
     requestOnDidMount: false,
   };
 
-  state = {
+  state: DataServiceState<D> = {
     requesting: false,
-    data: undefined,
   };
 
   /**
@@ -44,7 +46,7 @@ export class DataService extends React.PureComponent<DataServiceProps, DataServi
     }
   }
 
-  componentDidUpdate({ queries: prevQs }: DataServiceProps) {
+  componentDidUpdate({ queries: prevQs }: DataServiceProps<D>) {
     const { queries } = this.props;
     if (Array.isArray(prevQs) && Array.isArray(queries) && !shallowequal(prevQs, queries)) {
       this._getData(queries);

--- a/src/select/__test__/index.test.tsx
+++ b/src/select/__test__/index.test.tsx
@@ -1,12 +1,54 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import AweSelect from '..';
+import Select, { OptionProps } from '..';
+
+const options: OptionProps[] = [
+  { label: 'Option 1', value: 'option-1' },
+  { label: 'Option 2', value: 'option-2' },
+];
 
 describe('Testing <AweSelect />', () => {
-  test('rendered without errors.', () => {
-    render(<AweSelect />);
+  test('Using JSX style to render options.', async () => {
+    render(
+      <Select>
+        <Select.Option value="option-1">Option 1</Select.Option>
+        <Select.Option value="option-2">Option 2</Select.Option>
+      </Select>
+    );
 
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  test('Using `options` prop to render options.', async () => {
+    render(<Select options={options} />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+  });
+
+  test('Local filtering by `option.label`.', async () => {
+    render(<Select showSearch options={options} />);
+
+    const select = screen.getByRole('combobox');
+
+    await userEvent.click(select);
+
+    expect(screen.getByText('Option 1')).toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
+
+    const input = select.querySelector('.ant-select-search__field');
+
+    // Note that in the filter procedure,
+    // the whitespaces will be trimmed before the matching,
+    // and case insensitive.
+    await userEvent.type(input, '   option 2   ');
+
+    expect(screen.queryByText('Option 1')).toBeNull();
+    expect(screen.getByText('Option 2')).toBeInTheDocument();
   });
 });

--- a/src/select/__test__/index.test.tsx
+++ b/src/select/__test__/index.test.tsx
@@ -45,7 +45,7 @@ describe('Testing <AweSelect />', () => {
 
     // Note that in the filter procedure,
     // the whitespaces will be trimmed before the matching,
-    // and case insensitive.
+    // and it's case insensitive.
     await userEvent.type(input, '   option 2   ');
 
     expect(screen.queryByText('Option 1')).toBeNull();

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -1,15 +1,46 @@
 import React from 'react';
-import Select, { SelectProps } from 'antd/lib/select';
+import AntSelect, { SelectProps as AntSelectProps, OptionProps } from 'antd/lib/select';
 
-export interface AweSelectProps extends SelectProps {}
+export { OptionProps };
 
-export class AweSelect extends React.PureComponent<AweSelectProps> {
-  static OptGroup = Select.OptGroup;
-  static Option = Select.Option;
+export interface SelectProps extends AntSelectProps {
+  options?: OptionProps[];
+}
+
+export class Select extends React.PureComponent<SelectProps> {
+  static OptGroup = AntSelect.OptGroup;
+  static Option = AntSelect.Option;
+
+  static defaultProps = {
+    optionFilterProp: 'children',
+  };
 
   render() {
-    return <Select {...this.props} />;
+    const { options, children, ...props } = this.props;
+    const filterOption = generateFilterOption(this.props.optionFilterProp!);
+
+    return (
+      <AntSelect filterOption={filterOption} {...props}>
+        {options
+          ? options.map((option) => (
+              <AntSelect.Option key={option.value} {...option}>
+                {option.label}
+              </AntSelect.Option>
+            ))
+          : children}
+      </AntSelect>
+    );
   }
 }
 
-export default AweSelect;
+export default Select;
+
+function generateFilterOption(optionFilterProp: string) {
+  return (
+    inputValue: string,
+    option: React.ReactElement<OptionProps & { [prop: string]: string }>
+  ) =>
+    String(option.props[optionFilterProp])
+      .toLowerCase()
+      .includes(String(inputValue).trim().toLowerCase());
+}

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -16,11 +16,14 @@ export class Select extends React.PureComponent<SelectProps> {
   };
 
   render() {
-    const { options, children, ...props } = this.props;
-    const filterOption = generateFilterOption(this.props.optionFilterProp!);
+    const { filterOption, options, children, ...props } = this.props;
+    const defaultFilterOption = generateFilterOption(this.props.optionFilterProp!);
 
     return (
-      <AntSelect filterOption={filterOption} {...props}>
+      <AntSelect
+        filterOption={filterOption === undefined ? defaultFilterOption : filterOption}
+        {...props}
+      >
         {options
           ? options.map((option) => (
               <AntSelect.Option key={option.value} {...option}>

--- a/src/stories/ApiSelect.stories.mdx
+++ b/src/stories/ApiSelect.stories.mdx
@@ -33,47 +33,77 @@ import { dataService } from './ApiSelect';
 
 Will call `dataService` on `ApiSelect` component focused.
 
-<Story
-  name="Focus Mode"
-  args={{
-    style: { width: 200 },
-    allowClear: true,
-    showSearch: true,
-    defaultValue: 'option-1',
-    dataService: () => dataService('Option'),
-  }}
->
-  {(args) => <ApiSelect {...args} />}
-</Story>
+<Canvas>
+  <Story
+    name="Focus Mode"
+    args={{
+      style: { width: 200 },
+      allowClear: true,
+      showSearch: true,
+      defaultValue: 'option-1',
+      dataService: () => dataService('Option'),
+    }}
+  >
+    {(args) => <ApiSelect {...args} />}
+  </Story>
+</Canvas>
 
 No data retrieved.
 
-<Story
-  name="Focus Mode - No Data"
-  args={{
-    style: { width: 200 },
-    allowClear: true,
-    showSearch: true,
-    dataService: dataService,
-  }}
->
-  {(args) => <ApiSelect {...args} />}
-</Story>
+<Canvas>
+  <Story
+    name="Focus Mode - No Data"
+    args={{
+      style: { width: 200 },
+      allowClear: true,
+      showSearch: true,
+      dataService: dataService,
+    }}
+  >
+    {(args) => <ApiSelect {...args} />}
+  </Story>
+</Canvas>
 
 ### Did Mount Mode
 
 Will call `dataService` on `ApiSelect` component did mounted.
 
+<Canvas>
+  <Story
+    name="Did Mount Mode"
+    args={{
+      style: { width: 200 },
+      allowClear: true,
+      showSearch: true,
+      trigger: 'onDidMount',
+      defaultValue: 'option-1',
+      dataService: () => dataService('Option'),
+    }}
+  >
+    {(args) => <ApiSelect {...args} />}
+  </Story>
+</Canvas>
+
+### Service Queries
+
+Will call `dataService` when `serviceQueries` changes.
+
 <Story
-  name="Did Mount Mode"
+  name="Service Queries"
   args={{
     style: { width: 200 },
     allowClear: true,
-    showSearch: true,
-    trigger: 'onDidMount',
-    defaultValue: 'option-1',
-    dataService: () => dataService('Option'),
+    serviceQueries: ['Option'],
+    dataService: dataService,
   }}
+  decorators={[
+    (Story) => (
+      <div>
+        <h4>Try to change the `serviceQueries` to `["Awesome antd"]` in the `Controls` addon.</h4>
+        <Story />
+      </div>
+    ),
+  ]}
 >
   {(args) => <ApiSelect {...args} />}
 </Story>

--- a/src/stories/ApiSelect.stories.mdx
+++ b/src/stories/ApiSelect.stories.mdx
@@ -1,0 +1,79 @@
+import { Canvas, Story, Meta, ArgsTable, Description } from '@storybook/addon-docs/blocks';
+
+import ApiSelect from './../api-select';
+import { dataService } from './ApiSelect';
+
+<Meta title="Example/ApiSelect" component={ApiSelect} />
+
+# ApiSelect
+
+<Description>ApiSelect component to select value from remote options.</Description>
+
+<Canvas>
+  <Story
+    name="Search Mode"
+    args={{
+      style: { width: 200 },
+      allowClear: true,
+      trigger: 'onSearch',
+      dataService: dataService,
+    }}
+  >
+    {(args) => <ApiSelect {...args} />}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={ApiSelect} />
+
+## Stories
+
+### Focus Mode
+
+Will call `dataService` on `ApiSelect` component focused.
+
+<Story
+  name="Focus Mode"
+  args={{
+    style: { width: 200 },
+    allowClear: true,
+    showSearch: true,
+    defaultValue: 'option-1',
+    dataService: () => dataService('Option'),
+  }}
+>
+  {(args) => <ApiSelect {...args} />}
+</Story>
+
+No data retrieved.
+
+<Story
+  name="Focus Mode - No Data"
+  args={{
+    style: { width: 200 },
+    allowClear: true,
+    showSearch: true,
+    dataService: dataService,
+  }}
+>
+  {(args) => <ApiSelect {...args} />}
+</Story>
+
+### Did Mount Mode
+
+Will call `dataService` on `ApiSelect` component did mounted.
+
+<Story
+  name="Did Mount Mode"
+  args={{
+    style: { width: 200 },
+    allowClear: true,
+    showSearch: true,
+    trigger: 'onDidMount',
+    defaultValue: 'option-1',
+    dataService: () => dataService('Option'),
+  }}
+>
+  {(args) => <ApiSelect {...args} />}
+</Story>

--- a/src/stories/ApiSelect/index.tsx
+++ b/src/stories/ApiSelect/index.tsx
@@ -5,8 +5,8 @@ export const dataService = (keyword: string) =>
       3 * 1000,
       keyword
         ? [
-            { label: keyword + ' 1', value: 'option-1' },
-            { label: keyword + ' 2', value: 'option-2' },
+            { label: keyword + ' 1', value: keyword + '-1' },
+            { label: keyword + ' 2', value: keyword + '-2' },
           ]
         : undefined
     )

--- a/src/stories/ApiSelect/index.tsx
+++ b/src/stories/ApiSelect/index.tsx
@@ -1,0 +1,13 @@
+export const dataService = (keyword: string) =>
+  new Promise((resolve) =>
+    setTimeout(
+      resolve,
+      3 * 1000,
+      keyword
+        ? [
+            { label: keyword + ' 1', value: 'option-1' },
+            { label: keyword + ' 2', value: 'option-2' },
+          ]
+        : undefined
+    )
+  );

--- a/src/stories/FiltersForm/index.tsx
+++ b/src/stories/FiltersForm/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { InputNumber } from 'antd';
 
 import { createFiltersForm, FormItem, FiltersFormProps } from './../../filters-form';
-import AweInput from './../../input';
+import Input from './../../input';
 import Select from './../../select';
 
 import './../../filters-form/style';
@@ -32,10 +32,10 @@ const FiltersForm = createFiltersForm<FieldsValue, { onFieldsChange: OnFieldsCha
 });
 
 export const items: FormItem[] = [
-  { label: 'User Name', id: 'username', control: <AweInput /> },
+  { label: 'User Name', id: 'username', control: <Input /> },
   { label: 'Age', id: 'age', control: <InputNumber /> },
   { label: 'Salary', id: 'salary', control: <InputNumber /> },
-  { label: 'Job', id: 'job', control: <AweInput /> },
+  { label: 'Job', id: 'job', control: <Input /> },
   {
     label: 'Gender',
     id: 'gender',
@@ -47,7 +47,7 @@ export const items: FormItem[] = [
       </Select>
     ),
   },
-  { label: 'Children', id: 'children', control: <AweInput /> },
+  { label: 'Children', id: 'children', control: <Input /> },
 ];
 
 const App: React.FC<Props> = ({ defaultExpanded = false, onFieldsChange, onSearch, onReset }) => {

--- a/src/stories/FiltersForm/index.tsx
+++ b/src/stories/FiltersForm/index.tsx
@@ -3,7 +3,7 @@ import { InputNumber } from 'antd';
 
 import { createFiltersForm, FormItem, FiltersFormProps } from './../../filters-form';
 import AweInput from './../../input';
-import AweSelect from './../../select';
+import Select from './../../select';
 
 import './../../filters-form/style';
 
@@ -40,11 +40,11 @@ export const items: FormItem[] = [
     label: 'Gender',
     id: 'gender',
     control: (
-      <AweSelect allowClear>
-        <AweSelect.Option value="F">Female</AweSelect.Option>
-        <AweSelect.Option value="M">Male</AweSelect.Option>
-        <AweSelect.Option value="UNKNOW">Unknow</AweSelect.Option>
-      </AweSelect>
+      <Select allowClear>
+        <Select.Option value="F">Female</Select.Option>
+        <Select.Option value="M">Male</Select.Option>
+        <Select.Option value="UNKNOW">Unknow</Select.Option>
+      </Select>
     ),
   },
   { label: 'Children', id: 'children', control: <AweInput /> },

--- a/src/stories/Input.stories.mdx
+++ b/src/stories/Input.stories.mdx
@@ -1,16 +1,16 @@
 import { Canvas, Story, Meta, ArgsTable, Source, Description } from '@storybook/addon-docs/blocks';
 
-import AweInput from './../input';
+import Input from './../input';
 
 <Meta
-  title="Example/AweInput"
-  component={AweInput}
+  title="Example/Input"
+  component={Input}
   argTypes={{ size: { control: { type: 'radio', options: ['small', 'middle', 'large'] } } }}
 />
 
-export const Template = (args) => <AweInput {...args} />;
+export const Template = (args) => <Input {...args} />;
 
-# AweInput
+# Input
 
 <Description>To input text.</Description>
 
@@ -23,17 +23,17 @@ export const Template = (args) => <AweInput {...args} />;
       maxLength: 10,
     }}
   >
-    {(args) => <AweInput {...args} />}
+    {(args) => <Input {...args} />}
   </Story>
 </Canvas>
 
 ## Props
 
-<ArgsTable of={AweInput} />
+<ArgsTable of={Input} />
 
-## AweInput.TextArea Props
+## Input.TextArea Props
 
-<ArgsTable of={AweInput.TextArea} />
+<ArgsTable of={Input.TextArea} />
 
 ## Stories
 
@@ -46,6 +46,6 @@ export const Template = (args) => <AweInput {...args} />;
       maxLength: 10,
     }}
   >
-    {(args) => <AweInput.TextArea {...args} />}
+    {(args) => <Input.TextArea {...args} />}
   </Story>
 </Canvas>

--- a/src/stories/Select.stories.mdx
+++ b/src/stories/Select.stories.mdx
@@ -1,0 +1,51 @@
+import { Canvas, Story, Meta, ArgsTable, Description } from '@storybook/addon-docs/blocks';
+
+import Select from './../select';
+
+<Meta title="Example/Select" component={Select} />
+
+# Select
+
+<Description>Select component to select value from options.</Description>
+
+<Canvas>
+  <Story
+    name="Local filtering"
+    args={{
+      style: { width: 200 },
+      showSearch: true,
+      options: [
+        { label: 'Option 1', value: 'option-1' },
+        { label: 'Option 2', value: 'option-2' },
+      ],
+    }}
+  >
+    {(args) => <Select {...args} />}
+  </Story>
+</Canvas>
+
+## Props
+
+<ArgsTable of={Select} />
+
+### OptionProps
+
+Ref: [OptionProps@Select@antd@3.x](https://3x.ant.design/components/select/#Option-props)
+
+## Features Beyond `Select@antd@3.x`
+
+- [x] Define the select options by `options` prop.
+- [x] Use `option.label` to filter options by default.
+
+## Stories
+
+### JSX Style Options
+
+<Canvas>
+  <Story name="JSX Style Options">
+    <Select style={{ width: 200 }}>
+      <Select.Option value="option-1">Option 1</Select.Option>
+      <Select.Option value="option-2">Option 2</Select.Option>
+    </Select>
+  </Story>
+</Canvas>


### PR DESCRIPTION
#### Renaming
- AweSelect -> Select
- AweApiSelect -> ApiSelect
- AweInput -> Input

#### APIs

##### Select
- `options`: use this prop as a datasource to render select options

#### Default Behaviors

##### Select
- Set default `filterOption` to filter options by `option.label`

##### ApiSelect
- Turn on `showSearch` in `search mode`
- Turn off `filterOption` in `search mode`
- Does not call `dataService` any more when `search value` cleared in `search mode`
- Use default `filterOption` when not in `search mode`
- Hide `notFoundContent` at the very 1st time
- Show loading icon while `dataService` is calling in process
