### PR TITLE
New API `allowSearchOnClear` for `Input.Search` Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@galiojs/awesome-antd",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galiojs/awesome-antd",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "main": "es/index.js",
   "license": "MIT",
   "dependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,19 +2,38 @@ export * from 'antd/lib';
 
 export { default as AweTreeSelect } from './tree-select';
 
+/**
+ * @deprecated Use `Select`
+ */
 export { default as AweSelect } from './select';
 export { default as Select } from './select';
 
+/**
+ * @deprecated Use `ApiSelect`
+ */
 export { default as AweApiSelect } from './api-select';
 export { default as ApiSelect } from './api-select';
 
 export { default as AweCascader } from './cascader';
-export { default as AweApiCascader } from './api-cascader';
 
+/**
+ * @deprecated Use `ApiCascader`
+ */
+export { default as AweApiCascader } from './api-cascader';
+export { default as ApiCascader } from './api-cascader';
+
+/**
+ * @deprecated Use `Input`
+ */
 export { default as AweInput } from './input';
 export { default as Input } from './input';
 
 export { default as AweTag } from './tag';
 export { default as AweButton } from './button';
 export { default as AweTable, createEditableTable } from './table';
+
+/**
+ * @deprecated Use `FiltersForm`
+ */
 export { default as AweFiltersForm, createFiltersForm } from './filters-form';
+export { default as FiltersForm } from './filters-form';

--- a/src/input/__test__/index.test.tsx
+++ b/src/input/__test__/index.test.tsx
@@ -2,21 +2,21 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import AweInput from '..';
+import Input from '..';
 
 describe('Testing <AweInput />', () => {
   test('Show the maximum length and count ,uncontrolled', () => {
-    render(<AweInput maxLength={10} showLengthCount />);
+    render(<Input maxLength={10} showLengthCount />);
 
     expect(screen.queryByText('5/10')).toBeNull();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('5/10')).toBeInTheDocument();
   });
 
   test('Show the maximum length and count,have default value,uncontrolled ', async () => {
-    render(<AweInput maxLength={10} showLengthCount defaultValue="我是默认的值！" />);
+    render(<Input maxLength={10} showLengthCount defaultValue="我是默认的值！" />);
 
     expect(screen.queryByText('7/10')).toBeInTheDocument();
 
@@ -26,37 +26,37 @@ describe('Testing <AweInput />', () => {
   });
 
   test('Show the maximum length and count ,controlled', () => {
-    render(<AweInput maxLength={5} showLengthCount value="值" />);
+    render(<Input maxLength={5} showLengthCount value="值" />);
 
     expect(screen.queryByText('1/5')).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('1/5')).toBeInTheDocument();
   });
 
   test('Show the count ,controlled', () => {
-    render(<AweInput showLengthCount value="值" />);
+    render(<Input showLengthCount value="值" />);
 
     expect(screen.queryByText('1')).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('1')).toBeInTheDocument();
   });
 
   test("Don't show the count ,controlled", () => {
-    render(<AweInput value="值" />);
+    render(<Input value="值" />);
 
     expect(screen.queryByText('1')).toBeNull();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('1')).toBeNull();
   });
 
   test("Don't show the count ,uncontrolled", async () => {
-    render(<AweInput showLengthCount />);
+    render(<Input showLengthCount />);
 
     expect(screen.queryByText('0')).toBeInTheDocument();
     await userEvent.type(screen.getByRole('textbox'), '12');
@@ -64,30 +64,56 @@ describe('Testing <AweInput />', () => {
   });
 
   test('Show the maximum length and count ,value is undefined', () => {
-    render(<AweInput value={undefined} maxLength={10} showLengthCount />);
+    render(<Input value={undefined} maxLength={10} showLengthCount />);
 
     expect(screen.queryByText('0/10')).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('0/10')).toBeInTheDocument();
   });
 
   test('Show the maximum length and count, controlled, TextArea', () => {
-    render(<AweInput.TextArea value={undefined} maxLength={10} showLengthCount />);
+    render(<Input.TextArea value={undefined} maxLength={10} showLengthCount />);
 
     expect(screen.queryByText('0/10')).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'hello' }
+      target: { value: 'hello' },
     });
     expect(screen.queryByText('0/10')).toBeInTheDocument();
   });
 
   test('Show the maximum length and count, beyond the control of length, uncontrolled, TextArea', async () => {
-    render(<AweInput.TextArea maxLength={4} showLengthCount />);
+    render(<Input.TextArea maxLength={4} showLengthCount />);
 
     expect(screen.queryByText('0/4')).toBeInTheDocument();
     await userEvent.type(screen.getByRole('textbox'), 'hellohello111111111');
     expect(screen.getByText('4/4')).toBeInTheDocument();
+  });
+
+  test('The effect of `allowSearchOnClear` on `onSearch`', async () => {
+    const txt = 'try to click on the clear icon';
+    const searchHandler = jest.fn(() => {
+      /* noop */
+    });
+
+    const { rerender } = render(
+      <Input.Search allowClear allowSearchOnClear={false} onSearch={searchHandler} />
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), txt);
+    await userEvent.click(screen.getByLabelText('icon: search'));
+    await userEvent.click(screen.getByLabelText('icon: close-circle'));
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('value', '');
+    expect(searchHandler.mock.calls.length).toBe(1);
+
+    rerender(<Input.Search allowClear allowSearchOnClear onSearch={searchHandler} />);
+
+    await userEvent.type(screen.getByRole('textbox'), txt);
+    await userEvent.click(screen.getByLabelText('icon: close-circle'));
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('value', '');
+    expect(searchHandler.mock.calls.length).toBe(2);
   });
 });

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -3,6 +3,7 @@ import AntInput, { InputProps as AntInputProps } from 'antd/lib/input';
 
 import LengthCount from './length-count';
 import TextArea from './textarea';
+import Search from './search';
 
 export interface InputProps extends AntInputProps {
   showLengthCount: boolean;
@@ -11,7 +12,7 @@ export interface InputProps extends AntInputProps {
 export class Input extends React.PureComponent<InputProps> {
   static TextArea = TextArea;
   static Password = AntInput.Password;
-  static Search = AntInput.Search;
+  static Search = Search;
   static Group = AntInput.Group;
 
   static defaultProps = {

--- a/src/input/search.tsx
+++ b/src/input/search.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import omit from 'lodash.omit';
+import AntInput, { SearchProps as AntSearchProps } from 'antd/lib/input';
+
+export interface SearchProps extends AntSearchProps {
+  /**
+   * Trigger `onSearch` on clear icon clicked or not.
+   *
+   * > Prerequisite: `allowClear: true`
+   * @default true
+   */
+  allowSearchOnClear: boolean;
+}
+
+export class Search extends React.Component<SearchProps> {
+  static defaultProps = {
+    allowSearchOnClear: true,
+  };
+
+  _searchHandler = (
+    value: string,
+    event?:
+      | React.ChangeEvent<HTMLInputElement>
+      | React.KeyboardEvent<HTMLInputElement>
+      | React.MouseEvent<HTMLElement, MouseEvent>
+      | undefined
+  ) => {
+    const { allowClear, allowSearchOnClear, onSearch } = this.props;
+
+    if (!onSearch) {
+      return;
+    }
+
+    // It's totally a hack here.
+    // See: https://github.com/ant-design/ant-design/issues/18729
+    if (allowClear && !allowSearchOnClear && event && event.type === 'click') {
+      const path = (event as React.MouseEvent<HTMLElement, MouseEvent>).nativeEvent.composedPath();
+      const hasClearIcon = path.some((target) => {
+        if (target instanceof HTMLElement) {
+          return [...target.classList].some((className) => className.endsWith('clear-icon'));
+        }
+        return false;
+      });
+      if (hasClearIcon) {
+        return;
+      }
+    }
+
+    onSearch(value, event);
+  };
+
+  render() {
+    return (
+      <AntInput.Search
+        {...omit(this.props, ['allowSearchOnClear', 'onSearch'])}
+        onSearch={this._searchHandler}
+      />
+    );
+  }
+}
+
+export default Search;

--- a/src/stories/Input.stories.mdx
+++ b/src/stories/Input.stories.mdx
@@ -5,7 +5,10 @@ import Input from './../input';
 <Meta
   title="Example/Input"
   component={Input}
-  argTypes={{ size: { control: { type: 'radio', options: ['small', 'middle', 'large'] } } }}
+  argTypes={{
+    size: { control: { type: 'radio', options: ['small', 'middle', 'large'] } },
+    onChange: { action: 'onChange' },
+  }}
 />
 
 export const Template = (args) => <Input {...args} />;
@@ -37,6 +40,8 @@ export const Template = (args) => <Input {...args} />;
 
 ## Stories
 
+### Textarea
+
 <Canvas>
   <Story
     name="Textarea"
@@ -47,5 +52,26 @@ export const Template = (args) => <Input {...args} />;
     }}
   >
     {(args) => <Input.TextArea {...args} />}
+  </Story>
+</Canvas>
+
+### Disallow fire `onSearch` on clear icon clicked
+
+The Input.Search(antd@3.x) component would fire `onSearch` when `allowClear` is `true`, as per [this issue](https://github.com/ant-design/ant-design/issues/18729). But we might not need it in some cases(edge cases), and here is the a workaround for you: sets `allowSearchOnClear` to `false`, that's it.
+
+<Canvas>
+  <Story
+    name="Search - Reduce Search Events"
+    args={{
+      style: { width: 400 },
+      allowClear: true,
+      allowSearchOnClear: false,
+      defaultValue: 'Hover me and click the clear icon on the right',
+    }}
+    argTypes={{
+      onSearch: { action: 'onSearch' },
+    }}
+  >
+    {(args) => <Input.Search {...args} />}
   </Story>
 </Canvas>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitAny": true,
-    "lib": ["DOM", "ES2017"],
+    "lib": ["DOM", "DOM.Iterable", "ES2017"],
     "skipLibCheck": true
   },
   "include": ["src/**/*.tsx"],


### PR DESCRIPTION
The Input.Search(antd@3.x) component would fire `onSearch` when `allowClear` is `true`, as per [this issue](https://github.com/ant-design/ant-design/issues/18729). But we might not need it in some cases(edge cases), and here is the a workaround for you: sets `allowSearchOnClear` to `false`, that's it.